### PR TITLE
Add SVG table parser for svg color font parsing

### DIFF
--- a/src/tabs/SVG.js
+++ b/src/tabs/SVG.js
@@ -1,0 +1,33 @@
+Typr.SVG = {};
+Typr.SVG.parse = function(data, offset, length)
+{
+  var bin = Typr._bin;
+  var obj = { entries: []};
+
+  var offset0 = offset;
+
+  var tableVersion = bin.readUshort(data, offset);  offset += 2;
+  var svgDocIndexOffset = bin.readUint(data, offset);  offset += 4;
+  var reserved = bin.readUint(data, offset); offset += 4;
+
+  offset = svgDocIndexOffset + offset0;
+
+  var numEntries = bin.readUshort(data, offset);  offset += 2;
+
+  for(var i=0; i<numEntries; i++)
+  {
+    var startGlyphID = bin.readUshort(data, offset);  offset += 2;
+    var endGlyphID = bin.readUshort(data, offset);  offset += 2;
+    var svgDocOffset = bin.readUint(data, offset);  offset += 4;
+    var svgDocLength = bin.readUint(data, offset); offset += 4;
+
+    var svg = bin.readASCII(data, offset0 + svgDocOffset + svgDocIndexOffset, svgDocLength);
+
+    for(var f=startGlyphID; f<=endGlyphID; f++){
+      obj.entries[f] = svg;
+    }
+  }
+
+  return obj;
+
+}

--- a/src/tabs/join.sh
+++ b/src/tabs/join.sh
@@ -3,4 +3,4 @@
 
 
 cat cff.js  cmap.js  glyf.js  GPOS.js  GSUB.js  head.js  hhea.js  \
-hmtx.js  kern.js  loca.js  maxp.js  name.js  os-2.js   post.js  >  tabs.js
+hmtx.js  kern.js  loca.js  maxp.js  name.js  os-2.js   post.js SVG.js >  tabs.js


### PR DESCRIPTION
see https://www.colorfonts.wtf/ and https://www.microsoft.com/typography/otspec/svg.htm

This currently only parses the data, maybe the utilities could add some methods to draw all of this into a canvas context. What do you think?