### PR TITLE
Fix ligature sequences longer than 4

### DIFF
--- a/src/Typr.U.js
+++ b/src/Typr.U.js
@@ -277,7 +277,7 @@ Typr.U._getWPfeature = function(str, ci) {  // get Word Position feature
 	return feat;
 }
 Typr.U._applySubs = function(gls, ci, tab, llist) {
-	var rlim = Math.min(3, gls.length-ci-1);
+	var rlim = gls.length-ci-1;
 	//if(ci==0) console.log("++++ ", tab.ltype);
 	for(var j=0; j<tab.tabs.length; j++)
 	{


### PR DESCRIPTION
`Typr.U._applySubs` was applying a hard upper limit that ignored any ligature chains longer than 4. This breaks some fonts that use longer ligatures, such as the [Material Icons](https://material.io/resources/icons/?style=baseline) font, causing some sequences to go unmatched or to incorrectly match a different sequence of shorter length.

A few examples of how this manifested in Material Icons:
- `book` would be replaced correctly
- `backup` would not be replaced (too long)
- `https` would incorrectly be replaced with the ligature for `http` since its first 4 glyphs match that shorter chain

Removing the hard limit fixes these cases.