### PR TITLE
Correct parsing of negative values in fvar table

### DIFF
--- a/src/Typr.js
+++ b/src/Typr.js
@@ -242,7 +242,8 @@ Typr["T"]={};
 Typr["B"] = {
 	readFixed : function(data, o)
 	{
-		return ((data[o]<<8) | data[o+1]) +  (((data[o+2]<<8)|data[o+3])/(256*256+4));
+		var value = Typr["B"].readInt(data, o);
+    	return value / 65536;
 	},
 	readF2dot14 : function(data, o)
 	{
@@ -1934,4 +1935,5 @@ Typr["T"].HVAR = {
 		
 		return [regs,dfs];
 	}
+
 };


### PR DESCRIPTION
Here's a description you can copy-paste for your PR:

## Fix: Correct parsing of negative values in fvar table

### Problem
The `readFixed` function in Typr.js was incorrectly parsing negative values in the fvar table. Variable fonts like Roboto Flex use negative values for design axes (e.g., `slnt` axis with min: -10, `GRAD` axis with min: -200), but these were being interpreted as very large positive numbers (65526, 65336, etc.).

### Root Cause
The original `readFixed` implementation treated the 32-bit fixed-point numbers as unsigned integers:

```javascript
// Before: Buggy implementation
readFixed: function (data, o) {
  return (
    ((data[o] << 8) | data[o + 1]) +
    ((data[o + 2] << 8) | data[o + 3]) / (256 * 256 + 4)
  );
},
```

This approach treated the high 16 bits as unsigned, causing negative values to be interpreted as large positive numbers due to two's complement representation.

### Solution
Fixed the `readFixed` function to properly handle signed 32-bit integers:

```javascript
// After: Correct implementation
readFixed: function (data, o) {
  var value = Typr["B"].readInt(data, o);
  return value / 65536;
},
```

### Why 65536?
In OpenType fonts, fixed-point numbers are stored as 32-bit integers where:
- High 16 bits represent the integer part
- Low 16 bits represent the fractional part
- `65536 = 2^16` is the scale factor that converts between the integer representation and the actual floating-point values

By using the existing `readInt` function (which properly handles signed integers) and dividing by 65536, we correctly convert the fixed-point format to floating-point values while preserving negative values.

### Impact
This fix ensures that variable font axes with negative values (like `slnt`, `GRAD`, `YTDE` in Roboto Flex) are parsed correctly, enabling proper support for design axes that use negative ranges.